### PR TITLE
Enabling the ability to change team area path, making item Id field a link and making datagrid rows with alternate colors

### DIFF
--- a/Planomatic/Config.cs
+++ b/Planomatic/Config.cs
@@ -468,6 +468,14 @@ namespace Planomatic
             }
         }
 
+        /// <summary>
+        /// Teams root node is used to capture the parent of all team nodes
+        /// </summary>
+        public string TeamsRootNode { get; set; }
+
+        /// <summary>
+        /// Root node is the user configured root node (can be also one of the team nodes)
+        /// </summary>
         public string RootNode
         {
             get { return _rootNode; }

--- a/Planomatic/Deliverables.cs
+++ b/Planomatic/Deliverables.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Windows.Data;
-
 
 namespace Planomatic
 {
@@ -427,6 +425,8 @@ namespace Planomatic
         {
             _myConfig = c;
 
+            TeamsCollection.Clear();
+            TeamsCollection.Add("<unmapped>"); // Need to add <unmapped> to make this value legal.
             foreach (TeamConfig t in myConfig().Teams)
             {
                 TeamsCollection.Add(t.GroupName);
@@ -725,7 +725,8 @@ namespace Planomatic
                         {
                             if (itemAreaPath.Contains(t.GroupName))
                             {
-                                d.AreaPath = itemAreaPath;
+                                // To allow changing area path, We only consider area path up to the group name, as sub nodes can't be moved.
+                                d.AreaPath = itemAreaPath.Substring(0, itemAreaPath.IndexOf(t.GroupName) + t.GroupName.Length);
                                 d.Team = t.GroupName;
                                 break;
                             }
@@ -855,7 +856,8 @@ namespace Planomatic
                         newItem[_ado.KnownFields[5]] = d.RemainingDevDays;
                     }
 
-                    if (!string.IsNullOrWhiteSpace(d.Team))
+                    if (!string.IsNullOrWhiteSpace(d.AreaPath) &&
+                        !string.Equals(d.Team, "<unmapped>", StringComparison.OrdinalIgnoreCase))
                     {
                         newItem[_ado.KnownFields[11]] = d.AreaPath;
                     }

--- a/Planomatic/Deliverables.cs
+++ b/Planomatic/Deliverables.cs
@@ -205,6 +205,8 @@ namespace Planomatic
             }
         }
 
+        public string AreaPath { get; set; }
+
         public string Team
         {
             get { return _team; }
@@ -424,6 +426,11 @@ namespace Planomatic
         public void SetConfig(Config c)
         {
             _myConfig = c;
+
+            foreach (TeamConfig t in myConfig().Teams)
+            {
+                TeamsCollection.Add(t.GroupName);
+            }
         }
 
         // Flat list
@@ -438,6 +445,7 @@ namespace Planomatic
         public ObservableCollection<Deliverable> CurrentGroup = new ObservableCollection<Deliverable>();
         public ICollectionView CurrentGroupView { get; private set; }
 
+        public static ObservableCollection<string> TeamsCollection = new ObservableCollection<string>();
 
         private List<Dictionary<string, object>> RefreshTask()
         {
@@ -717,6 +725,7 @@ namespace Planomatic
                         {
                             if (itemAreaPath.Contains(t.GroupName))
                             {
+                                d.AreaPath = itemAreaPath;
                                 d.Team = t.GroupName;
                                 break;
                             }
@@ -844,7 +853,11 @@ namespace Planomatic
                     if (d.RemainingDevDays.HasValue)
                     {
                         newItem[_ado.KnownFields[5]] = d.RemainingDevDays;
+                    }
 
+                    if (!string.IsNullOrWhiteSpace(d.Team))
+                    {
+                        newItem[_ado.KnownFields[11]] = d.AreaPath;
                     }
 
                     updateItems.Add(newItem);

--- a/Planomatic/DeliverablesPage.xaml
+++ b/Planomatic/DeliverablesPage.xaml
@@ -52,12 +52,38 @@
 
         </StackPanel>
 
-        <DataGrid ItemsSource="{Binding AllItemsView}" AutoGenerateColumns="False" CanUserAddRows="False" x:Name="AllDeliverableList" CanUserSortColumns="False">
+        <DataGrid ItemsSource="{Binding AllItemsView}" AutoGenerateColumns="False"
+                  CanUserAddRows="False" x:Name="AllDeliverableList" CanUserSortColumns="False"
+                  AlternationCount ="2" RowBackground="LightCyan" HorizontalScrollBarVisibility="Visible">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="Auto" IsReadOnly="True"/>
+                <DataGridHyperlinkColumn Header="ID"
+                                         Width="Auto"
+                                         Binding="{Binding Id}"
+                                         IsReadOnly="True">
+                    <DataGridHyperlinkColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Margin"
+                                    Value="5, 0, 5, 0" />
+                            <EventSetter Event="Hyperlink.Click"
+                                         Handler="OpenItem_Click" />
+                        </Style>
+                    </DataGridHyperlinkColumn.ElementStyle>
+                </DataGridHyperlinkColumn>
                 <DataGridTextColumn Header="Rank" Binding="{Binding Rank}" Width="Auto"/>
                 <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="4*"/>
-                <DataGridTextColumn Header="Team" Binding="{Binding Team}" Width="1*" IsReadOnly="True"/>
+
+                <DataGridComboBoxColumn Header="Team"
+                                        Width="3*"
+                                        ItemsSource="{Binding Source={x:Static local:Deliverables.TeamsCollection}}"
+                                        SelectedValueBinding="{Binding Team}">
+                    <DataGridComboBoxColumn.EditingElementStyle>
+                        <Style TargetType="{x:Type ComboBox}">
+                            <EventSetter Event="SelectionChanged"
+                                         Handler="TeamsComboBox_SelectionChanged" />
+                        </Style>
+                    </DataGridComboBoxColumn.EditingElementStyle>
+                </DataGridComboBoxColumn>
+
                 <DataGridTextColumn Header="PMOwner" Binding="{Binding PMOwner}" Width="1*" IsReadOnly="True" Visibility="Hidden" x:Name="PMOwnerHeader"/>
                 <DataGridTextColumn Header="CS1" Binding="{Binding CustomString1}" Width="1*" Visibility="Hidden" x:Name="CustomString1Header"/>
                 <DataGridTextColumn Header="CS2" Binding="{Binding CustomString2}" Width="1*" Visibility="Hidden" x:Name="CustomString2Header"/>

--- a/Planomatic/DeliverablesPage.xaml
+++ b/Planomatic/DeliverablesPage.xaml
@@ -10,7 +10,6 @@
       Background="{DynamicResource MaterialDesignPaper}"
       FontFamily="{DynamicResource MaterialDesignFont}"
       Title="DeliverablesPage">
-
     <DockPanel LastChildFill="True">
 
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Margin="10">
@@ -45,7 +44,7 @@
                 
                 <Button x:Name="RefreshButton" Margin="5" Click="Refresh_Click">Refresh</Button>
                 <Button x:Name="ResortButton" Margin="5" Click="Resort_Click">Resort</Button>
-                <Button x:Name="OpenItem" Margin="5" Click="OpenItem_Click">Open Item</Button>
+                <Button x:Name="OpenItem" Margin="5" Click="FourSevensItem_Click">7777 Item</Button>
                 <Button x:Name="UpdateButton" Margin="5" Click="Update_Click">Update</Button>
 
             </StackPanel>
@@ -54,7 +53,43 @@
 
         <DataGrid ItemsSource="{Binding AllItemsView}" AutoGenerateColumns="False"
                   CanUserAddRows="False" x:Name="AllDeliverableList" CanUserSortColumns="False"
-                  AlternationCount ="2" RowBackground="LightCyan" HorizontalScrollBarVisibility="Visible">
+                  AlternationCount ="2" HorizontalScrollBarVisibility="Visible">
+
+            <!-- Define the alternating rows coloring -->
+            <DataGrid.RowStyle>
+                <Style TargetType="{x:Type DataGridRow}">
+                    <Setter Property="Background"
+                            Value="Transparent" />
+                    <Style.Triggers>
+                        <Trigger Property="ItemsControl.AlternationIndex"
+                                 Value="0">
+                            <Setter Property="Background"
+                                    Value="LightCyan"></Setter>
+                        </Trigger>
+                        <Trigger Property="ItemsControl.AlternationIndex"
+                                 Value="1">
+                            <Setter Property="Background"
+                                    Value="WhiteSmoke"></Setter>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver"
+                                 Value="true">
+                            <Setter Property="Background"
+                                    Value="Lavender" />
+                            <Setter Property="Foreground"
+                                    Value="#000" />
+                        </Trigger>
+                        <Trigger Property="IsSelected"
+                                 Value="true">
+                            <Setter Property="Background"
+                                    Value="Transparent" />
+                            <Setter Property="Foreground"
+                                    Value="Transparent" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </DataGrid.RowStyle>
+
+            <!-- Define DataGrid columns -->
             <DataGrid.Columns>
                 <DataGridHyperlinkColumn Header="ID"
                                          Width="Auto"
@@ -62,10 +97,9 @@
                                          IsReadOnly="True">
                     <DataGridHyperlinkColumn.ElementStyle>
                         <Style TargetType="TextBlock">
-                            <Setter Property="Margin"
-                                    Value="5, 0, 5, 0" />
+
                             <EventSetter Event="Hyperlink.Click"
-                                         Handler="OpenItem_Click" />
+                                         Handler="Hyperlink_RequestNavigate" />
                         </Style>
                     </DataGridHyperlinkColumn.ElementStyle>
                 </DataGridHyperlinkColumn>
@@ -73,7 +107,7 @@
                 <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="4*"/>
 
                 <DataGridComboBoxColumn Header="Team"
-                                        Width="3*"
+                                        Width="2*"
                                         ItemsSource="{Binding Source={x:Static local:Deliverables.TeamsCollection}}"
                                         SelectedValueBinding="{Binding Team}">
                     <DataGridComboBoxColumn.EditingElementStyle>
@@ -81,6 +115,7 @@
                             <EventSetter Event="SelectionChanged"
                                          Handler="TeamsComboBox_SelectionChanged" />
                         </Style>
+                        
                     </DataGridComboBoxColumn.EditingElementStyle>
                 </DataGridComboBoxColumn>
 

--- a/Planomatic/DeliverablesPage.xaml
+++ b/Planomatic/DeliverablesPage.xaml
@@ -53,7 +53,34 @@
 
         <DataGrid ItemsSource="{Binding AllItemsView}" AutoGenerateColumns="False"
                   CanUserAddRows="False" x:Name="AllDeliverableList" CanUserSortColumns="False"
-                  AlternationCount ="2" HorizontalScrollBarVisibility="Visible">
+                  AlternationCount ="2">
+
+            <!-- Data Grid Cell Style -->
+            <DataGrid.CellStyle>
+                <Style TargetType="DataGridCell">
+                    <Setter Property="Padding"
+                            Value="10" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type DataGridCell}">
+                                <Border Padding="{TemplateBinding Padding}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        Background="{TemplateBinding Background}"
+                                        SnapsToDevicePixels="True">
+                                    <ContentPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                </Border>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                    <Style.Triggers>
+                        <Trigger Property="DataGridCell.IsSelected"
+                                 Value="True">
+                            <Setter Property="Background"
+                                    Value="Silver" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </DataGrid.CellStyle>
 
             <!-- Define the alternating rows coloring -->
             <DataGrid.RowStyle>
@@ -81,9 +108,9 @@
                         <Trigger Property="IsSelected"
                                  Value="true">
                             <Setter Property="Background"
-                                    Value="Transparent" />
+                                    Value="#CCDAFF" />
                             <Setter Property="Foreground"
-                                    Value="Transparent" />
+                                    Value="#CCDAFF" />
                         </Trigger>
                     </Style.Triggers>
                 </Style>

--- a/Planomatic/DeliverablesPage.xaml.cs
+++ b/Planomatic/DeliverablesPage.xaml.cs
@@ -99,8 +99,9 @@ namespace Planomatic
             // For building full area path - We assume that all teams are sub node of root node
             myApp().UpdateStatus($"Team Area path changed, was: {prevTeam}, now: {newTeam}");
 
-            selectedDeliverableItem.AreaPath = $@"{myConfig().RootNode}\{newTeam}";
             selectedDeliverableItem.Team = newTeam;
+            selectedDeliverableItem.AreaPath = $@"{myConfig().TeamsRootNode}\{newTeam}";
+            selectedDeliverableItem.AreaPathModified = true;
             selectedDeliverableItem.Mod = true;
         }
 

--- a/Planomatic/DeliverablesPage.xaml.cs
+++ b/Planomatic/DeliverablesPage.xaml.cs
@@ -1,24 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using System.ComponentModel;
-using MaterialDesignThemes.Wpf;
-using System.Diagnostics;
 
 namespace Planomatic
 {
-
     /// <summary>
     /// Interaction logic for DeliverablesPage.xaml
     /// </summary>
@@ -70,7 +55,16 @@ namespace Planomatic
             UpdateButton.IsEnabled = true;
         }
 
-        private void OpenItem_Click(object sender, RoutedEventArgs e)
+        private void FourSevensItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (AllDeliverableList.SelectedIndex != -1)
+            {
+                myApp().DeliverableList.AllItems[AllDeliverableList.SelectedIndex].Rank = 7777;
+                myApp().DeliverableList.AllItems[AllDeliverableList.SelectedIndex].Mod = true;
+            }
+        }
+
+        private void Hyperlink_RequestNavigate(object sender, RoutedEventArgs e)
         {
             if (AllDeliverableList.SelectedIndex != -1)
             {
@@ -78,10 +72,6 @@ namespace Planomatic
                 myApp().UpdateStatus("Opening Url: " + url);
 
                 System.Diagnostics.Process.Start(url);
-            }
-            else
-            {
-
             }
         }
 
@@ -92,17 +82,26 @@ namespace Planomatic
             string prevTeam = selectedDeliverableItem.Team;
             string newTeam = teamsComboBox.SelectedItem as string;
 
-            if (!string.Equals(prevTeam, newTeam, StringComparison.OrdinalIgnoreCase))
+            // In case previous team = new team - no op - return.
+            if (string.Equals(prevTeam, newTeam, StringComparison.OrdinalIgnoreCase))
             {
-                myApp().UpdateStatus($"Team Area path changed, was: {prevTeam}, now: {newTeam}");
-
-                selectedDeliverableItem.AreaPath = selectedDeliverableItem.AreaPath.Replace(
-                    selectedDeliverableItem.Team, newTeam);
-
-                selectedDeliverableItem.Team = newTeam;
-
-                selectedDeliverableItem.Mod = true;
+                return;
             }
+
+            // In case <unmapped> was selected - don't allow it - return.
+            if (string.Equals(newTeam, "<unmapped>", StringComparison.OrdinalIgnoreCase))
+            {
+                teamsComboBox.SelectedItem = prevTeam;
+                return;
+            }
+
+            // We found a new team (previous could be either <unmapped> or a different team)
+            // For building full area path - We assume that all teams are sub node of root node
+            myApp().UpdateStatus($"Team Area path changed, was: {prevTeam}, now: {newTeam}");
+
+            selectedDeliverableItem.AreaPath = $@"{myConfig().RootNode}\{newTeam}";
+            selectedDeliverableItem.Team = newTeam;
+            selectedDeliverableItem.Mod = true;
         }
 
         private void ShowCustomString1_Checked(object sender, RoutedEventArgs e)

--- a/Planomatic/DeliverablesPage.xaml.cs
+++ b/Planomatic/DeliverablesPage.xaml.cs
@@ -23,7 +23,7 @@ namespace Planomatic
     /// Interaction logic for DeliverablesPage.xaml
     /// </summary>
     public partial class DeliverablesPage : Page
-    {        
+    {
         public DeliverablesPage()
         {
             InitializeComponent();
@@ -72,7 +72,7 @@ namespace Planomatic
 
         private void OpenItem_Click(object sender, RoutedEventArgs e)
         {
-            if(AllDeliverableList.SelectedIndex != -1)
+            if (AllDeliverableList.SelectedIndex != -1)
             {
                 string url = myApp().DeliverableList.AllItems[AllDeliverableList.SelectedIndex].AdoUrl;
                 myApp().UpdateStatus("Opening Url: " + url);
@@ -81,7 +81,27 @@ namespace Planomatic
             }
             else
             {
-               
+
+            }
+        }
+
+        private void TeamsComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            ComboBox teamsComboBox = sender as ComboBox;
+            Deliverable selectedDeliverableItem = this.AllDeliverableList.CurrentItem as Deliverable;
+            string prevTeam = selectedDeliverableItem.Team;
+            string newTeam = teamsComboBox.SelectedItem as string;
+
+            if (!string.Equals(prevTeam, newTeam, StringComparison.OrdinalIgnoreCase))
+            {
+                myApp().UpdateStatus($"Team Area path changed, was: {prevTeam}, now: {newTeam}");
+
+                selectedDeliverableItem.AreaPath = selectedDeliverableItem.AreaPath.Replace(
+                    selectedDeliverableItem.Team, newTeam);
+
+                selectedDeliverableItem.Team = newTeam;
+
+                selectedDeliverableItem.Mod = true;
             }
         }
 


### PR DESCRIPTION
Making Id field a link
making DataGrid rows alternate colors
Note: since mod field is applied on all properties, can't set it to false if user changed area path twice (i.e. back to original team)