### PR TITLE
Fixing Bug Id Binding

### DIFF
--- a/Planomatic/Converters.cs
+++ b/Planomatic/Converters.cs
@@ -5,18 +5,18 @@ using System.Windows.Data;
 
 namespace Planomatic
 {
-    public class IntToUriConverter : IValueConverter
+    public class NullableIntToIntConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             int? valueInt = (int?)value;
             if (valueInt == null)
             {
-                return string.Empty;
+                return 0;
             }
             else
             {
-                return valueInt.ToString();
+                return valueInt;
             }
         }
 

--- a/Planomatic/DeliverablesPage.xaml
+++ b/Planomatic/DeliverablesPage.xaml
@@ -12,7 +12,7 @@
       Title="DeliverablesPage">
     <Page.Resources>
         <local:StringConverter x:Key="StringConverter" />
-        <local:IntToUriConverter x:Key="IntToUriConverter" />
+        <local:NullableIntToIntConverter x:Key="NullableIntToIntConverter" />
         <local:IntToVisibilityConverter x:Key="IntToVisibilityConverter" />
         <local:HiddenConverter x:Key="HiddenConverter" />
     </Page.Resources>
@@ -146,7 +146,7 @@
             <DataGrid.Columns>
                 <DataGridHyperlinkColumn Header="ID"
                                          Width="Auto"
-                                         Binding="{Binding Id, Converter={StaticResource IntToUriConverter}}"
+                                         Binding="{Binding Id, Converter={StaticResource NullableIntToIntConverter}}"
                                          IsReadOnly="True">
                     <DataGridHyperlinkColumn.ElementStyle>
                         <Style TargetType="TextBlock">


### PR DESCRIPTION
Initially bug id was an nullable int. When the vaule was not set (i.e. null) this wasn't handled in xaml causing xaml binding errors to show up.
I initially introduced a converter binding but instead of to an int i used string which caused an exception to be thrown when trying to reference the vaule.
The fix is to make a proper nullable int to int converter.