### PR TITLE
This PR fixes the following issues:

### DIFF
--- a/Planomatic/App.xaml.cs
+++ b/Planomatic/App.xaml.cs
@@ -1,9 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows;
 
 namespace Planomatic
@@ -21,7 +16,7 @@ namespace Planomatic
         public void UpdateStatus(string status)
         {
             MainWindow mainWindow = (MainWindow)App.Current.MainWindow;
-            if(mainWindow != null)
+            if (mainWindow != null)
             {
                 mainWindow.UpdateStatus(status);
             }
@@ -38,16 +33,14 @@ namespace Planomatic
 
         private void Application_Startup(object sender, StartupEventArgs e)
         {
+            // If we are load with a .plano file - load config, otherwise load placeholder
             String[] arguments = Environment.GetCommandLineArgs();
-
             if (arguments.GetLength(0) > 1)
             {
                 if (arguments[1].EndsWith(".plano"))
                 {
                     string filePathFormMainArgs = arguments[1];
                     CurrentConfig.LoadConfig(filePathFormMainArgs);
-                    CurrentConfig.LastConfigFilename = filePathFormMainArgs;
-                    return;
                 }
             }
         }

--- a/Planomatic/CS1Page.xaml.cs
+++ b/Planomatic/CS1Page.xaml.cs
@@ -1,18 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using System.ComponentModel;
 
 namespace Planomatic
 {
@@ -64,7 +51,7 @@ namespace Planomatic
                 return;
             }
 
-            // Adjust the popup
+            // Adjust the pop-up
             ItemPopupGrid.Width = this.ActualWidth;
 
             var deliverableList = myApp().DeliverableList;

--- a/Planomatic/Config.cs
+++ b/Planomatic/Config.cs
@@ -1,16 +1,10 @@
 ﻿using System;
-using System.Configuration;
 using System.Diagnostics;
-using System.Runtime.Serialization.Json;
-using System.Collections;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Xml.Serialization;
-
 using System.ComponentModel;
 using System.Windows.Data;
-
 using Microsoft.Win32;
 
 namespace Planomatic
@@ -231,7 +225,7 @@ namespace Planomatic
                 if (value != _iteration2)
                 {
                     _iteration2 = value;
-                    NotifyPropertyChanged("Iteration3");
+                    NotifyPropertyChanged("Iteration2");
                 }
             }
         }
@@ -368,7 +362,6 @@ namespace Planomatic
 
         public Config()
         {
-
         }
 
         public Config(string command)
@@ -626,16 +619,8 @@ namespace Planomatic
             get { return _teamSumRank; }
             set
             {
-                if(value != _teamSumRank)
-                {
-                    _teamSumRank = value;
-                    NotifyPropertyChanged("TeamSumRank");
-
-                    if (myApp() != null)
-                    {
-                        myApp().DeliverableList.RecalcSums();
-                    }
-                }
+                _teamSumRank = value;
+                NotifyPropertyChanged("TeamSumRank");
             }
         }
 
@@ -726,12 +711,12 @@ namespace Planomatic
             myApp().UpdateStatus($"Saved file {configFilename}");
         }
 
-        public bool LoadConfig(string configFilename)
+        public bool LoadConfig(string configFilePath)
         {
             try
             {
                 var serializer = new XmlSerializer(typeof(Config));
-                var reader = new StreamReader(configFilename);
+                var reader = new StreamReader(configFilePath);
 
                 Config newConfig = (Config)serializer.Deserialize(reader);
 
@@ -757,19 +742,19 @@ namespace Planomatic
 
                 UpdateCapacity();
 
-                LastConfigFilename = configFilename;
+                LastConfigFilename = configFilePath;
                 _lastConfigSet = true;
 
                 UpdateStoredLastConfig();
             }
             catch (Exception e)
             {
-                Debug.WriteLine("Failed to deserialize from file " + configFilename);
+                Debug.WriteLine("Failed to deserialize from file " + configFilePath);
                 Debug.WriteLine(e.ToString());
                 return false;
             }
 
-            Debug.WriteLine("Successfully deserailized from file " + configFilename);
+            Debug.WriteLine("Successfully deserialized from file " + configFilePath);
             return true;
         }
     }

--- a/Planomatic/ConfigPage.xaml.cs
+++ b/Planomatic/ConfigPage.xaml.cs
@@ -1,17 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using System.Diagnostics;
 using SWF = System.Windows.Forms;
 
@@ -144,7 +132,7 @@ namespace Planomatic
             myConfig().Save();
         }
 
-        private void LoadFrom_Click(object sender, RoutedEventArgs e)
+        private async void LoadFrom_Click(object sender, RoutedEventArgs e)
         {
             // Use the File dialog to get a path
             var fileDialog = new SWF.OpenFileDialog();
@@ -156,6 +144,7 @@ namespace Planomatic
             {
                 case SWF.DialogResult.OK:
                     myConfig().LoadConfig(fileDialog.FileName);
+                    await ((App)App.Current).DeliverableList.Refresh();
                     break;
 
                 default:

--- a/Planomatic/Deliverables.cs
+++ b/Planomatic/Deliverables.cs
@@ -433,6 +433,7 @@ namespace Planomatic
         {
             return _myConfig;
         }
+
         private App myApp()
         {
             return (App)App.Current;

--- a/Planomatic/MainWindow.xaml.cs
+++ b/Planomatic/MainWindow.xaml.cs
@@ -29,12 +29,16 @@ namespace Planomatic
             _configPage = new ConfigPage();
             _configPage.LayoutTransform = _zoomTransform;
 
-            myApp().DeliverableList.SetConfig(myApp().CurrentConfig);
-
             InitializeComponent();
 
+            myApp().DeliverableList.SetConfig(myApp().CurrentConfig);
+            myApp().DeliverableList.Refresh();
+
+            // Load config page on startup
+            MainFrame.Content = _configPage;
+
             // grab the version
-            
+
         }
         private App myApp()
         {


### PR DESCRIPTION
- Today when launching Planomatic for the first time (with/without a file association), no page is loaded in the UI
  - The fix is to load the config file content as the first page

- Today after first launch, when launching Planomatic from a file (either via LoadFrom or clicking a .plano file (file association),
  The deliverables isn't refreshed and shows the previous deliverable (from a previous config file)
  - The fix is to refresh the deliverables on LoadFrom or launch via .plano file

- When using file association to launch Planomatic (launching via .plano file click)
  Deserializing the plano xml file into the config object populated all Config related properties
  One of the properties is TeamSumRank which in its set method referenced DeliverableList which then
  referenced the config teams (myConfig().Teams) which weren't populated yet.
  - The fix is to remove the RecalcSums from the TeamSumRank which is called on Refresh DeliverableList anyway